### PR TITLE
Fix citation formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ If you use our models or our corpus, please cite our article:
     author = {Kummervold, Per E  and
       De la Rosa, Javier  and
       Wetjen, Freddy  and
-      Brygfjeld, Svein Arne",
+      Brygfjeld, Svein Arne},
     booktitle = {Proceedings of the 23rd Nordic Conference on Computational Linguistics (NoDaLiDa)},
-    year = "2021",
-    address = "Reykjavik, Iceland (Online)",
+    year = {2021},
+    address = {Reykjavik, Iceland (Online)},
     publisher = {Link{\"o}ping University Electronic Press, Sweden},
-    url = "https://aclanthology.org/2021.nodalida-main.3",
-    pages = "20--29",
-    abstract = "In this work, we show the process of building a large-scale training set from digital and digitized collections at a national library. The resulting Bidirectional Encoder Representations from Transformers (BERT)-based language model for Norwegian outperforms multilingual BERT (mBERT) models in several token and sequence classification tasks for both Norwegian Bokm{\aa}l and Norwegian Nynorsk. Our model also improves the mBERT performance for other languages present in the corpus such as English, Swedish, and Danish. For languages not included in the corpus, the weights degrade moderately while keeping strong multilingual properties. Therefore, we show that building high-quality models within a memory institution using somewhat noisy optical character recognition (OCR) content is feasible, and we hope to pave the way for other memory institutions to follow.",
+    url = {https://aclanthology.org/2021.nodalida-main.3},
+    pages = {20--29},
+    abstract = {In this work, we show the process of building a large-scale training set from digital and digitized collections at a national library. The resulting Bidirectional Encoder Representations from Transformers (BERT)-based language model for Norwegian outperforms multilingual BERT (mBERT) models in several token and sequence classification tasks for both Norwegian Bokm{\aa}l and Norwegian Nynorsk. Our model also improves the mBERT performance for other languages present in the corpus such as English, Swedish, and Danish. For languages not included in the corpus, the weights degrade moderately while keeping strong multilingual properties. Therefore, we show that building high-quality models within a memory institution using somewhat noisy optical character recognition (OCR) content is feasible, and we hope to pave the way for other memory institutions to follow.},
     }


### PR DESCRIPTION
Fix citation to not use {}-encapsulation for all fields.

Probably the world's smallest fix, but it annoyed me while writing my thesis, so figured I'd change it to make life easier for anyone wanting to use the citations in the future.

I am by no means doing this to say "Hey, look how I contributed to a large language model", so feel free to deny the PR if you fear for that!